### PR TITLE
Workaround to fix Stretch compatibility

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -26,7 +26,7 @@ final_path=/var/www/$app
 sudo rm -rf $final_path
 sudo mkdir -p $final_path
 echo "Downloading phpLDAPadmin $version..."
-sudo wget -O ../phpLDAPadmin.tar.gz http://sourceforge.net/projects/phpldapadmin/files/phpldapadmin-php5/$version/phpldapadmin-$version.tgz/download > /dev/null 2>&1
+sudo wget -O ../phpLDAPadmin.tar.gz http://sourceforge.net/projects/phpldapadmin/files/phpldapadmin-php%35/$version/phpldapadmin-$version.tgz/download > /dev/null 2>&1
 echo "Extracting to $final_path..."
 sudo tar xvzf ../phpLDAPadmin.tar.gz -C ..  > /dev/null 2>&1
 sudo cp  -ar ../phpldapadmin-$version/. $final_path

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -22,7 +22,7 @@ final_path=/var/www/$app
 sudo rm -rf $final_path
 sudo mkdir -p $final_path
 echo "Downloading phpLDAPadmin $version..."
-sudo wget -O ../phpLDAPadmin.tar.gz http://sourceforge.net/projects/phpldapadmin/files/phpldapadmin-php5/$version/phpldapadmin-$version.tgz/download > /dev/null 2>&1
+sudo wget -O ../phpLDAPadmin.tar.gz http://sourceforge.net/projects/phpldapadmin/files/phpldapadmin-php%35/$version/phpldapadmin-$version.tgz/download > /dev/null 2>&1
 echo "Extracting to $final_path..."
 sudo tar xvzf ../phpLDAPadmin.tar.gz -C ..  > /dev/null 2>&1
 sudo cp  -ra ../phpldapadmin-$version/. $final_path


### PR DESCRIPTION
Prevent YunoHost core to replace the "php5" part of the upstream URL to php7.0... in a somewhat hackish way :sweat_smile: